### PR TITLE
Fix software apprenticeship syllabus

### DIFF
--- a/interfaces_software_engineer/README.md
+++ b/interfaces_software_engineer/README.md
@@ -1,12 +1,12 @@
-# Software Apprenticehip - Interfaces [Client Applications, Web Applicatons, Mobile applications]
+# Software Apprenticeship - Interfaces [Client Applications, Web Applications, Mobile Applications]
 
 ## WEEK 1
 
 ### Topics to Cover 
 1. Functional Programming
 2. Functional Programming vs Other paradigms
-3. What is Elm 
-4. What is TEA 
+3. What is Elm? 
+4. What is TEA?
 6. What is Version Control? Why do we need it?
 
 
@@ -17,12 +17,12 @@
 3. https://guide.elm-lang.org/
 4. https://git-scm.com/book/en/v2/Getting-Started-About-Version-Control
 5. Find attached an introductory book on Elm also accessible here (https://guide.elm-lang.org)
-
+6. KnowThen Elm for Beginners Course (Covers 0.18) here (https://courses.knowthen.com/p/elm-for-beginners) 
 ### Challenges 
 1. Write a small narrative of how and when you would use a object oriented language
 2. Write a small narrative of how and when you would use a functional language
 3. Install Elm on your machine and get it to work 
-4. Read about The Elm Artchitechture in your course work material
+4. Read about The Elm architecture in your course work material
 5. Create a GitHub Account and join the Little Kidogo organization on GitHub
 
 
@@ -86,8 +86,8 @@
 3. Work with your Mentor to finalize the application you came up with in week 2
 
 ### Review Week
-1. Assesment on readiness to work on projects, evaluations and remedies recommended
-2. Research and Choosing of production projects 
+1. Assessment on readiness to work on projects, evaluations and possible areas of improvement recommended
+2. Research and selection of production projects 
 
 
 ## WEEK 5 
@@ -95,7 +95,7 @@
 ### Topics to cover 
 1. Contributing to work you don't own
 2. Reviewing work done by others
-3. Continous Integration
+3. Continuous Integration
 
 
 ### Reading Material
@@ -121,13 +121,13 @@
 1. Complete the issues assigned to you by your mentors and product owners 
 2. Complete a weekly review with recorded minutes
 3. Work together to help each other review their work.
-4. Complete atleast one of the tasks assigned to you as a pair
+4. Complete at least one of the tasks assigned to you as a pair
 
 ## WEEK 7 
 
 ### Topics to cover
 1. How to use agile methodologies when working
-2. Introduction to Agile and other Working styles 
+2. Introduction to Agile and other working styles 
 3. Working as a team 
 
 ### Reading Material 
@@ -141,7 +141,7 @@
 1. Work with a teammate to complete a sprint planning session 
 2. Work with a teammate to complete a sprint retrospective session 
 3. Compile a sprint plan and present it 
-4. Compile a sprint retrospective and prentent it
+4. Compile a sprint retrospective and present it
 
 ## WEEK 8 - 11  
 
@@ -157,7 +157,7 @@
 ### Challenges 
 1. Deploy a small webpage on Github pages to show your learning progress 
 2. Maintain the page and update it as you go along with your weekly reports 
-3. Read and write a report on all the sections of the digital ocean article in the Reading Material
+3. Read and write a report on all the sections of the DigitalOcean article in the reading material
 
 ## WEEK 12
 

--- a/systems_software_engineer/README.md
+++ b/systems_software_engineer/README.md
@@ -1,12 +1,12 @@
-# Software Developer Apprenticeship - Systems ~ish  [Server Services, Web Applicatons, Concurrent, Embedded Applications]
+# Software Developer Apprenticeship - Systems ~ish  [Server Services, Web Applications, Concurrent, Embedded Applications]
 
 ## WEEK 1
 
 ### Topics to Cover 
 1. Functional Programming
 2. Functional Programming vs Other paradigms
-3. What is Elixir 
-4. What is OTP 
+3. What is Elixir? 
+4. What is OTP?
 6. What is Version Control? Why do we need it?
 
 
@@ -20,8 +20,8 @@
 ### Challenges 
 1. Write a small narrative of how and when you would use a object oriented language
 2. Write a small narrative of how and when you would use a functional language
-3. Install Elixir on your machine and get it work 
-4. Read the foreword in the attached elixir book (only till the start of Conventional Programming
+3. Install Elixir on your machine and get it to work 
+4. Read the foreword in the attached elixir book (only till the start of Conventional Programming)
 5. Create a GitHub Account and join the Little Kidogo organization on GitHub
 
 
@@ -49,7 +49,7 @@
 1. Introduction to projects, linking this up to version control i.e issues, branches, pull requests, reviewing, merging, rebasing
 2. Putting Version Control to use 
 3. Introduction to peer work and review 
-4. Introduction to paragraphs an pages of code 
+4. Introduction to paragraphs and pages of code 
 
 ### Reading Material 
 1. Chapters 3 - 6 of the Elixir programming book
@@ -60,7 +60,7 @@
 1. Complete the code examples in the programming book
 2. Work in branches and in a git repository
 3. Use issues to document and plan your work 
-4. Use pull requests to introduce Changes
+4. Use pull requests to introduce changes
 
 ## WEEK 4 
 
@@ -84,7 +84,7 @@
 
 ### Review Week
 1. Assesment on readiness to work on projects, evaluations and remedies recommended
-2. Research and Choosing of production projects 
+2. Research and choosing of production projects 
 
 
 ## WEEK 5 
@@ -92,7 +92,7 @@
 ### Topics to cover 
 1. Contributing to work you don't own
 2. Reviewing work done by others
-3. Continous Integration
+3. Continuous Integration
 
 
 ### Reading Material
@@ -120,13 +120,13 @@
 1. Complete the issues assigned to you by your mentors and product owners 
 2. Complete a weekly review with recorded minutes
 3. Work together to help each other review their work.
-4. Complete atleast one of the tasks assigned to you as a pair
+4. Complete at least one of the tasks assigned to you as a pair
 
 ## WEEK 7 
 
 ### Topics to cover
 1. How to use agile methodologies when working
-2. Introduction to Agile and other Working styles 
+2. Introduction to Agile and other working styles 
 3. Working as a team 
 
 ### Reading Material 
@@ -140,7 +140,7 @@
 1. Work with a teammate to complete a sprint planning session 
 2. Work with a teammate to complete a sprint retrospective session 
 3. Compile a sprint plan and present it 
-4. Compile a sprint retrospective and prentent it
+4. Compile a sprint retrospective and present it
 
 ## WEEK 8 - 11  
 
@@ -155,7 +155,7 @@
 ### Challenges 
 1. Deploy a small webpage on Github pages to show your learning progress 
 2. Maintain the page and update it as you go along with your weekly reports 
-3. Read and write a report on all the sections of the article in the Reading Material
+3. Read and write a report on all the sections of the article in the reading material
 
 ## WEEK 12
 

--- a/systems_software_engineer/README.md
+++ b/systems_software_engineer/README.md
@@ -109,11 +109,12 @@
 1. Using libraries in applications
 2. Arranging your software code
 3. Pair Programming
+4. Code analysis - Credo
 
 ### Reading Material
 1. https://elixir-lang.org/getting-started/mix-otp/dependencies-and-umbrella-projects.html#external-dependencies
 2. Revisit Chapter 13 of the Elixir programming book 
-3. Libraries to look up(phoenix, absinthe, exunit, distillery, ecto)
+3. Libraries to look up(phoenix, absinthe, exunit, distillery, ecto, credo)
 4. https://en.wikipedia.org/wiki/Pair_programming
 
 ### Challenges


### PR DESCRIPTION
I have made some changes on the text/cleanup of typos.

@zacck do you think it would help to create a section for extra courseware? 
We could use this section to direct participants to places where they can get more guidance on some key features of each stack we are introducing. I have introduced a link but it would serve better in a section like this.

Your thoughts?